### PR TITLE
COMP: Use vtkMRMLLabelMapVolumeNode

### DIFF
--- a/DiceComputation/Logic/vtkSlicerDiceComputationLogic.cxx
+++ b/DiceComputation/Logic/vtkSlicerDiceComputationLogic.cxx
@@ -94,7 +94,7 @@ void vtkSlicerDiceComputationLogic
 
 //---------------------------------------------------------------------------
 void vtkSlicerDiceComputationLogic
-::ComputeDiceCoefficient(std::vector<vtkMRMLScalarVolumeNode*> labelMaps,
+::ComputeDiceCoefficient(std::vector<vtkMRMLLabelMapVolumeNode*> labelMaps,
                          std::vector<std::vector<double> >& resultsArray)
 {
 
@@ -114,8 +114,8 @@ void vtkSlicerDiceComputationLogic
     for (int j = 0; (j <= i) && (j < numberOfSamples); j++)
       {
       // Put -1 if one of the map is not selected
-      vtkMRMLScalarVolumeNode* labelMap1 = labelMaps[i];
-      vtkMRMLScalarVolumeNode* labelMap2 = labelMaps[j];
+      vtkMRMLLabelMapVolumeNode* labelMap1 = labelMaps[i];
+      vtkMRMLLabelMapVolumeNode* labelMap2 = labelMaps[j];
       if (labelMap1 != NULL && labelMap2 != NULL)
         {
         // Dice coeff of a map with itself is 1.0
@@ -250,8 +250,8 @@ void vtkSlicerDiceComputationLogic
 
 //---------------------------------------------------------------------------
 int vtkSlicerDiceComputationLogic
-::ComputeIntersection(vtkMRMLScalarVolumeNode* map1,
-                      vtkMRMLScalarVolumeNode* map2)
+::ComputeIntersection(vtkMRMLLabelMapVolumeNode* map1,
+                      vtkMRMLLabelMapVolumeNode* map2)
 {
   if (!map1 || !map2)
     {
@@ -291,9 +291,9 @@ int vtkSlicerDiceComputationLogic
 
 //---------------------------------------------------------------------------
 int vtkSlicerDiceComputationLogic
-::GetNumberOfPixels(vtkMRMLScalarVolumeNode* map)
+::GetNumberOfPixels(vtkMRMLLabelMapVolumeNode* map)
 {
-  if (!map || map->GetLabelMap() == 0)
+  if (!map)
     {
     return -1;
     }

--- a/DiceComputation/Logic/vtkSlicerDiceComputationLogic.h
+++ b/DiceComputation/Logic/vtkSlicerDiceComputationLogic.h
@@ -33,7 +33,7 @@
 #include "vtkSlicerModuleLogic.h"
 
 // MRML includes
-#include "vtkMRMLScalarVolumeNode.h"
+#include "vtkMRMLLabelMapVolumeNode.h"
 #include "vtkMRMLScene.h"
 #include "vtkPolyData.h"
 
@@ -53,7 +53,7 @@ public:
   vtkTypeMacro(vtkSlicerDiceComputationLogic, vtkSlicerModuleLogic);
   void PrintSelf(ostream& os, vtkIndent indent);
 
-  void ComputeDiceCoefficient(std::vector<vtkMRMLScalarVolumeNode*> labelMaps,
+  void ComputeDiceCoefficient(std::vector<vtkMRMLLabelMapVolumeNode*> labelMaps,
                               std::vector<std::vector<double> >& resultsArray);
   void ComputeHausdorffDistance(std::vector<vtkPolyData*> polyData,
 				std::vector<std::vector<double> >& resultsArray);
@@ -69,9 +69,9 @@ protected:
   virtual void OnMRMLSceneNodeAdded(vtkMRMLNode* node);
   virtual void OnMRMLSceneNodeRemoved(vtkMRMLNode* node);
 
-  int ComputeIntersection(vtkMRMLScalarVolumeNode* map1,
-                          vtkMRMLScalarVolumeNode* map2);
-  int GetNumberOfPixels(vtkMRMLScalarVolumeNode* map);
+  int ComputeIntersection(vtkMRMLLabelMapVolumeNode* map1,
+                          vtkMRMLLabelMapVolumeNode* map2);
+  int GetNumberOfPixels(vtkMRMLLabelMapVolumeNode* map);
   int GetNumberOfPixels(vtkImageData* imData);
 
 private:

--- a/DiceComputation/Widgets/qSlicerDiceComputationLabelMapSelectorWidget.cxx
+++ b/DiceComputation/Widgets/qSlicerDiceComputationLabelMapSelectorWidget.cxx
@@ -80,7 +80,7 @@ qSlicerDiceComputationLabelMapSelectorWidget
   d->LabelMapSelector->setNoneEnabled(true);
   d->LabelMapSelector->setShowChildNodeTypes(true);
   d->LabelMapSelector->setRenameEnabled(true);
-  d->LabelMapSelector->setNodeTypes(QStringList() << "vtkMRMLScalarVolumeNode" << "vtkMRMLModelNode");
+  d->LabelMapSelector->setNodeTypes(QStringList() << "vtkMRMLLabelMapVolumeNode" << "vtkMRMLModelNode");
 
   connect(d->LabelMapSelector, SIGNAL(currentNodeChanged(vtkMRMLNode*)),
 	  this, SLOT(onNodeChanged(vtkMRMLNode*)));
@@ -149,6 +149,7 @@ void qSlicerDiceComputationLabelMapSelectorWidget
   Q_D(qSlicerDiceComputationLabelMapSelectorWidget);
 
   // TODO: Set a flag to tell if label map or not
+    //TODO: It is now not a flag, but the node type that tells the labelmap and scalar volumes apart: vtkMRMLLabelMapVolumeNode
 
 /*
   if (!newNode || !newNode->IsA("vtkMRMLScalarVolumeNode"))

--- a/DiceComputation/qSlicerDiceComputationModuleWidget.cxx
+++ b/DiceComputation/qSlicerDiceComputationModuleWidget.cxx
@@ -41,6 +41,7 @@
 #include <vtkPointData.h>
 
 #include <vtkMRMLAnnotationROINode.h>
+#include <vtkMRMLLabelMapVolumeNode.h>
 #include <vtkSlicerCropVolumeLogic.h>
 
 //-----------------------------------------------------------------------------
@@ -52,7 +53,7 @@ public:
   ~qSlicerDiceComputationModuleWidgetPrivate();
 
   std::vector<std::vector<double> > resultsArray;
-  std::vector<vtkMRMLScalarVolumeNode*> labelMaps;
+  std::vector<vtkMRMLLabelMapVolumeNode*> labelMaps;
   std::vector<vtkPolyData*> polyData;
   std::vector<vtkImageData*> STAPLEImages;
   int labelMapSize;
@@ -236,14 +237,13 @@ bool qSlicerDiceComputationModuleWidget::findLabelMaps()
         = dynamic_cast<qSlicerDiceComputationLabelMapSelectorWidget*>(child->widget());
       if (tmpWidget)
         {
-	vtkMRMLScalarVolumeNode* currentNode 
-	  = vtkMRMLScalarVolumeNode::SafeDownCast(tmpWidget->getSelectedNode());
+	vtkMRMLLabelMapVolumeNode* currentNode 
+	  = vtkMRMLLabelMapVolumeNode::SafeDownCast(tmpWidget->getSelectedNode());
 	if (d->CropCheckbox->isChecked() && d->cropLogic && d->RoiWidget->mrmlROINode())
 	  {
-	  vtkSmartPointer<vtkMRMLScalarVolumeNode> croppedVolume
-	    = vtkSmartPointer<vtkMRMLScalarVolumeNode>::New();
+	  vtkSmartPointer<vtkMRMLLabelMapVolumeNode> croppedVolume
+	    = vtkSmartPointer<vtkMRMLLabelMapVolumeNode>::New();
 	  d->cropLogic->CropVoxelBased(d->RoiWidget->mrmlROINode(), currentNode, croppedVolume.GetPointer());
-	  croppedVolume->LabelMapOn();
 	  if (this->mrmlScene())
 	    {
 	    this->mrmlScene()->AddNode(croppedVolume.GetPointer());


### PR DESCRIPTION
A new class for labelmap nodes (vtkMRMLLabelmapNode) was introduced into the Slicer core
that replaces the old method of storing segmentation in a vtkMRMLScalarVolumeNode with
a custom “labelmap” attribute set to "1".
See details here:
http://www.slicer.org/slicerWiki/index.php/Documentation/Labs/Segmentations#vtkMRMLLabelMapVolumeNode_integration

This change in the Slicer core requires modification of your extension. See the suggested change in this commit.